### PR TITLE
Adding `bower install` compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.tmp
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "motio",
+  "version": "2.2.2",
+  "homepage": "https://github.com/WillemLabu/motio",
+  "main": "dist/motio.js",
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components"
+  ]
+}


### PR DESCRIPTION
Adding a `bower.json` file so we're able to install the repo via `bower install --save https://github.com/darsain/motio`.

I have noticed a small bug where the `bower.json` file doesn't get copied into the `bower_components/motio` directory after running the above `install`. No idea why this happens.

If you want to publish this to bower's public repo, run:

`bower register motio git://github.com/darasin/motio.git`

This is just my 2c.. Let me know what you think.

w
