### PR TITLE
CommonJSify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "motio",
-	"version": "0.0.0",
+	"version": "0.0.1",
+	"main": "src/motio.js",
 	"devDependencies": {
 		"grunt-contrib-jshint": "~0.7.2",
 		"grunt-contrib-concat": "~0.3.0",

--- a/src/motio.js
+++ b/src/motio.js
@@ -517,4 +517,8 @@
 		bgWidth:  0, // Width of the background image (optional).
 		bgHeight: 0  // Height of the background image (optional).
 	};
+
+	if (typeof exports === 'object' && typeof module === 'object') {
+		module.exports = Motio;
+	}
 })(window);


### PR DESCRIPTION
With these slight changed Motio is CommonJS/browserify compatible. 

For example, this is how I'm using it:

``` javascript
var Motio = require('motio');
...
...
_sprite = new Motio(element, {
            fps: 1,
            frames: numFrames,
            bgWidth: 11520,
            bgHeight: 6120,
            width: frameWidth,
            height: frameHeight,
            vertical:true,
        });
```
